### PR TITLE
kinda necessary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(name='pyoctopart',
           'pypandoc<=1.7.5'
         ],
       install_requires=[
-          'pypandoc<=1.7.5'
+          'pypandoc<=1.7.5',
           'pyoctopart',
           'requests',
           'setuptools'


### PR DESCRIPTION
```
pint(venv) ncotlar@mfnosson /mfab/Dockerfiles/deps/MFParts$ pip install -r requirements.txt
Looking in indexes: https://pypi.org/simple, https://mfdev_ro:****@pypi.development.macrofab.com/pypi
Collecting git+https://github.com/MacroFab/pyoctopart.git (from -r requirements.txt (line 4))
  Cloning https://github.com/MacroFab/pyoctopart.git to /tmp/pip-req-build-13zwvj7t
  Running command git clone --filter=blob:none --quiet https://github.com/MacroFab/pyoctopart.git /tmp/pip-req-build-13zwvj7t
  Resolved https://github.com/MacroFab/pyoctopart.git to commit 64b42a55c0ca6a37d1651cee5eb755cd80f1b670
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [27 lines of output]
      /mfab/Dockerfiles/deps/MFParts/venv/lib/python3.10/site-packages/setuptools/installer.py:27: SetuptoolsDeprecationWarning: setuptools.installer is deprecated. Requirements should be satisfied by a PEP 517 installer.
        warnings.warn(
      long_description_markdown_filename: dist = <setuptools.dist.Distribution object at 0x7f98edc147c0>; attr = 'long_description_markdown_filename'; value = 'README.md'
      markdown_filename = '/tmp/pip-req-build-13zwvj7t/README.md'
      [INFO] Maybe try:

          sudo apt-get install pandoc

      Maybe try:

          sudo apt-get install pandoc

      [INFO] See http://johnmacfarlane.net/pandoc/installing.html
      for installation options

      See http://johnmacfarlane.net/pandoc/installing.html
      for installation options

      [INFO] ---------------------------------------------------------------


      ---------------------------------------------------------------


      error in pyoctopart setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected end or semicolon (after version specifier)
          pypandoc<=1.7.5pyoctopart
                  ~~~~~~~^
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```